### PR TITLE
Gemspec cleanup

### DIFF
--- a/blockcypher-ruby.gemspec
+++ b/blockcypher-ruby.gemspec
@@ -1,12 +1,13 @@
 Gem::Specification.new do |s|
-  s.name        = 'Blockcypher Ruby SDK'
+  s.name        = 'blockcypher-ruby'
+  s.summary     = 'Blockcypher Ruby SDK'
   s.version     = '0.1.0'
   s.licenses    = ['Apache 2.0']
-  s.summary     = "Ruby library to help you build your crypto application on BlockCypher"
+  s.description = "Ruby library to help you build your crypto application on BlockCypher"
   s.authors     = ["CoinHako", "BlockCypher"]
   s.email       = 'contact@blockcypher.com'
-  s.files       = ["lib/client.rb"]
+  s.files       = Dir["{spec,lib}/**/*"] + %w(LICENSE README.md)
   s.homepage    = 'http://www.blockcypher.com'
-  
+
   s.add_runtime_dependency "bitcoin-ruby", ["~> 0.0.5"]
 end


### PR DESCRIPTION
Hi, I would like to sugest some changes.
In the moment to use this gem, I need to use `gem 'Blockcypher Ruby SDK', github: 'blockcypher/ruby-client'` in my Gemfile. I think the name `gem 'blockcypher-ruby', github: 'blockcypher/ruby-client'` is more idiomatic, because major of the gems use the downcase form separated by hyphen or underscore. I also changed the `files` field to lookup the files dynamically, and removed `lib/client.rb` which doesn't exist.
