### PR TITLE
Update ruby SDK with (almost) full API coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ If you want to use BTC on the main net, which is normally what you want to do, i
 
     block_cypher = BlockCypher::Api.new
 
-## Setting up payment forwarding
-
-    BlockCypher::Api.new.create_forwarding_address('your_forwarding_address', 'your_token')
-
 ## BlockCypher's documentation
 
 For more information check the API docs at:

--- a/blockcypher-ruby.gemspec
+++ b/blockcypher-ruby.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'blockcypher-ruby'
   s.summary     = 'Blockcypher Ruby SDK'
-  s.version     = '0.1.0'
+  s.version     = '0.2.0'
   s.licenses    = ['Apache 2.0']
   s.description = "Ruby library to help you build your crypto application on BlockCypher"
   s.summary     = "Ruby library to help you build your crypto application on BlockCypher"
@@ -15,6 +15,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", "~> 1.6"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
-  s.add_development_dependency "pry"
 end
 

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -1,13 +1,11 @@
-
-
 module BlockCypher
 
   V1 = 'v1'
 
   BTC = 'btc'
   LTC = 'ltc'
-	DOGE = 'doge'
-	BCY= 'bcy'
+  DOGE = 'doge'
+  BCY= 'bcy'
 
   MAIN_NET = 'main'
   TEST_NET = 'test'
@@ -30,9 +28,9 @@ module BlockCypher
     # Blockchain API
     ##################
 
-		def blockchain_unconfirmed_tx
-			api_http_get('/txs')
-		end
+    def blockchain_unconfirmed_tx
+      api_http_get('/txs')
+    end
 
     def blockchain_transaction(transaction_hash)
       api_http_get('/txs/' + transaction_hash)
@@ -42,27 +40,27 @@ module BlockCypher
       api_http_get('/blocks/' + block_index, query: params)
     end
 
-		def blockchain
-			api_http_get('')
-		end
+    def blockchain
+      api_http_get('')
+    end
 
-		##################
-		# Faucet API
-		##################
+    ##################
+    # Faucet API
+    ##################
 
-		def faucet(address, amount)
-			payload = { 'address' => address, 'amount' => amount }
-			api_http_post('/faucet', json_payload: payload)
-		end
+    def faucet(address, amount)
+      payload = { 'address' => address, 'amount' => amount }
+      api_http_post('/faucet', json_payload: payload)
+    end
 
     ##################
     # Transaction API
     ##################
     
-		def decode_hex(hex)
-			payload = { 'tx' => hex}
-			api_http_post('/txs/decode', json_payload: payload)
-		end
+    def decode_hex(hex)
+      payload = { 'tx' => hex}
+      api_http_post('/txs/decode', json_payload: payload)
+    end
 
     def push_hex(hex)
       payload = { 'tx' => hex }
@@ -98,74 +96,74 @@ module BlockCypher
     end
 
     def transaction_sign_and_send(new_tx, private_key)
-			pubkey = pubkey_from_priv(private_key)
-			# Make array of pubkeys matching length of 'tosign'
-			new_tx['pubkeys'] = Array.new(new_tx['tosign'].length) { pubkey }
-			# Sign the 'tosign' array
+      pubkey = pubkey_from_priv(private_key)
+      # Make array of pubkeys matching length of 'tosign'
+      new_tx['pubkeys'] = Array.new(new_tx['tosign'].length) { pubkey }
+      # Sign the 'tosign' array
       new_tx['signatures'] = signer(private_key, new_tx['tosign'])
       api_http_post('/txs/send', json_payload: new_tx)
     end
 
-		def pubkey_from_priv(private_key)
+    def pubkey_from_priv(private_key)
       key = Bitcoin::Key.new(private_key, nil, compressed = true)
       key.pub
-		end
+    end
 
-		def signer(private_key, tosign)
+    def signer(private_key, tosign)
       key = Bitcoin::Key.new(private_key, nil, compressed = true)
       signatures = []
 
-			tosign.each do |to_sign_hex|
+      tosign.each do |to_sign_hex|
         to_sign_binary = [to_sign_hex].pack("H*")
         sig_binary = key.sign(to_sign_binary)
         sig_hex = sig_binary.unpack("H*").first
         signatures << sig_hex
-			end
+      end
 
-			return signatures
-		end
+      return signatures
+    end
 
-		def transaction_new_custom(payload)
-			# Build payload yourself, for custom transactions
-			api_http_post('/txs/new', json_payload: payload)
-		end
+    def transaction_new_custom(payload)
+      # Build payload yourself, for custom transactions
+      api_http_post('/txs/new', json_payload: payload)
+    end
 
-		def transaction_send_custom(payload)
-			# Send TXSkeleton payload yourself, for custom transactions
-			# You may need to sign your data using another library, like Bitcoin
-			api_http_post('/txs/send', json_payload: payload)
-		end
+    def transaction_send_custom(payload)
+      # Send TXSkeleton payload yourself, for custom transactions
+      # You may need to sign your data using another library, like Bitcoin
+      api_http_post('/txs/send', json_payload: payload)
+    end
 
-		def tx_confidence(tx_hash)
-			api_http_get('/txs/' + tx_hash + '/confidence')
-		end
+    def tx_confidence(tx_hash)
+      api_http_get('/txs/' + tx_hash + '/confidence')
+    end
 
-		##################
-		# Microtx API
-		##################	
-		
-		# This method sends private key to server
-		def microtx_from_priv(private_key, to_address, value_satoshis)
-			payload = {
-				from_private: private_key,
-				to_address: to_address,
-				value_satoshis: value_satoshis
-			}
-			api_http_post('/txs/micro', json_payload: payload)
-		end
+    ##################
+    # Microtx API
+    ##################  
+    
+    # This method sends private key to server
+    def microtx_from_priv(private_key, to_address, value_satoshis)
+      payload = {
+        from_private: private_key,
+        to_address: to_address,
+        value_satoshis: value_satoshis
+      }
+      api_http_post('/txs/micro', json_payload: payload)
+    end
 
-		# This method uses public key, signs with private key locally
-		def microtx_from_pub(private_key, to_address, value_satoshis)
-			pubkey = pubkey_from_priv(private_key)
-			payload = {
-				from_pubkey: pubkey,
-				to_address: to_address,
-				value_satoshis: value_satoshis
-			}
-			micro_skel = api_http_post('/txs/micro', json_payload: payload)
-			micro_skel['signatures'] = signer(private_key, micro_skel['tosign'])
-			api_http_post('/txs/micro', json_payload: micro_skel)
-		end
+    # This method uses public key, signs with private key locally
+    def microtx_from_pub(private_key, to_address, value_satoshis)
+      pubkey = pubkey_from_priv(private_key)
+      payload = {
+        from_pubkey: pubkey,
+        to_address: to_address,
+        value_satoshis: value_satoshis
+      }
+      micro_skel = api_http_post('/txs/micro', json_payload: payload)
+      micro_skel['signatures'] = signer(private_key, micro_skel['tosign'])
+      api_http_post('/txs/micro', json_payload: micro_skel)
+    end
 
     ##################
     # Address APIs
@@ -175,18 +173,18 @@ module BlockCypher
       api_http_post('/addrs')
     end
 
-		def address_generate_multi(pubkeys, script_type)
-			payload = { 'pubkeys' => pubkeys, 'script_type' => script_type}
+    def address_generate_multi(pubkeys, script_type)
+      payload = { 'pubkeys' => pubkeys, 'script_type' => script_type}
       api_http_post('/addrs', json_payload: payload)
-		end
+    end
 
     def address_details(address, unspent_only: false)
       api_http_get('/addrs/' + address, query: { unspentOnly: unspent_only } )
     end
 
-		def address_balance(address)
-			api_http_get('/addrs/' + address + '/balance')
-		end
+    def address_balance(address)
+      api_http_get('/addrs/' + address + '/balance')
+    end
 
     def address_final_balance(address)
       details = address_balance(address)
@@ -197,40 +195,40 @@ module BlockCypher
       api_http_get("/addrs/#{address}/full")
     end
 
-		##################
-		# Wallet API
-		##################
-		
-		def wallet_create(name, addresses)
-			payload = { 'name' => name, 'addresses' => addresses}
+    ##################
+    # Wallet API
+    ##################
+    
+    def wallet_create(name, addresses)
+      payload = { 'name' => name, 'addresses' => addresses}
       api_http_post('/wallets', json_payload: payload)
-		end
+    end
 
-		def wallet_get(name)
-			api_http_get('/wallets/' + name)
-		end
+    def wallet_get(name)
+      api_http_get('/wallets/' + name)
+    end
 
-		def wallet_add_addr(name, addresses)
-			payload = { 'addresses' => addresses}
+    def wallet_add_addr(name, addresses)
+      payload = { 'addresses' => addresses}
       api_http_post('/wallets/' + name + '/addresses', json_payload: payload)
-		end
+    end
 
-		def wallet_get_addr(name)
-			api_http_get('/wallets/' + name + '/addresses')
-		end
+    def wallet_get_addr(name)
+      api_http_get('/wallets/' + name + '/addresses')
+    end
 
-		def wallet_delete_addr(name, addresses)
-			addrjoin = addresses.join(";")
-			api_http_delete('/wallets/' + name + '/addresses', query: { address: addrjoin})
-		end
+    def wallet_delete_addr(name, addresses)
+      addrjoin = addresses.join(";")
+      api_http_delete('/wallets/' + name + '/addresses', query: { address: addrjoin})
+    end
 
-		def wallet_gen_addr(name)
-			api_http_post('/wallets/' + name + '/addresses/generate')
-		end
+    def wallet_gen_addr(name)
+      api_http_post('/wallets/' + name + '/addresses/generate')
+    end
 
-		def wallet_delete(name)
-			api_http_delete('/wallets/' + name)
-		end
+    def wallet_delete(name)
+      api_http_delete('/wallets/' + name)
+    end
 
     ##################
     # Events API
@@ -248,17 +246,17 @@ module BlockCypher
       api_http_post('/hooks', json_payload: payload)
     end
 
-		def event_webhook_listall
-			api_http_get('/hooks')
-		end
+    def event_webhook_listall
+      api_http_get('/hooks')
+    end
 
-		def event_webhook_get(id)
-			api_http_get('/hooks/' + id)
-		end
+    def event_webhook_get(id)
+      api_http_get('/hooks/' + id)
+    end
 
-		def event_webhook_delete(id)
-			api_http_delete('/hooks/' + id)
-		end
+    def event_webhook_delete(id)
+      api_http_delete('/hooks/' + id)
+    end
 
     ##################
     # Payments and Forwarding API
@@ -279,9 +277,9 @@ module BlockCypher
       api_http_get("/payments")
     end
 
-		def delete_forwarding_address(id)
-			api_http_delete("/payments/" + id)
-		end
+    def delete_forwarding_address(id)
+      api_http_delete("/payments/" + id)
+    end
 
     private
 
@@ -297,8 +295,8 @@ module BlockCypher
         request = Net::HTTP::Post.new(uri.request_uri)
       elsif http_method == :get
         request = Net::HTTP::Get.new(uri.request_uri)
-			elsif http_method == :delete
-				request = Net::HTTP::Delete.new(uri.request_uri)
+      elsif http_method == :delete
+        request = Net::HTTP::Delete.new(uri.request_uri)
       else
         raise 'Invalid HTTP method'
       end
@@ -313,8 +311,8 @@ module BlockCypher
       # Detect errors/return 204 empty body
       if response.code == '400'
         raise Error.new(uri.to_s + ' Response:' + response.body)
-			elsif response.code == '204'
-				return nil
+      elsif response.code == '204'
+        return nil
       end
 
       # Process the response
@@ -334,9 +332,9 @@ module BlockCypher
       api_http_call(:post, api_path, query, json_payload: json_payload)
     end
 
-		def api_http_delete(api_path, query: {})
-			api_http_call(:delete, api_path, query)
-		end
+    def api_http_delete(api_path, query: {})
+      api_http_call(:delete, api_path, query)
+    end
 
     def endpoint_uri(api_path, query)
       uri = URI("https://api.blockcypher.com/#{@version}/#{@currency}/#{@network}#{api_path}")

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -236,19 +236,29 @@ module BlockCypher
     # Events API
     ##################
 
-    def event_webhook_subscribe(url, event, confirmations: nil,
-                                token:nil, hash:nil, address:nil, script:nil)
+    def event_webhook_subscribe(url, event, confirmations: nil, hash:nil, address:nil, script:nil)
       payload = {
         url: url,
         event: event,
       }
-      payload[:token] = token || @api_token if token || @api_token
       payload[:address] = address if address
       payload[:hash] = hash if hash
       payload[:script] = script if script
       payload[:confirmations] = confirmations if confirmations
       api_http_post('/hooks', json_payload: payload)
     end
+
+		def event_webhook_listall
+			api_http_get('/hooks')
+		end
+
+		def event_webhook_get(id)
+			api_http_get('/hooks/' + id)
+		end
+
+		def event_webhook_delete(id)
+			api_http_delete('/hooks/' + id)
+		end
 
     ##################
     # Payments and Forwarding API

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -239,9 +239,11 @@ module BlockCypher
 
       response = http.request(request)
 
-      # Detect errors
+      # Detect errors/return 204 empty body
       if response.code == '400'
         raise Error.new(uri.to_s + ' Response:' + response.body)
+			elsif response.code == '204'
+				return nil
       end
 
       # Process the response

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -30,6 +30,10 @@ module BlockCypher
     # Blockchain API
     ##################
 
+		def blockchain_unconfirmed_tx()
+			api_http_get('/txs')
+		end
+
     def blockchain_transaction(transaction_hash)
       api_http_get('/txs/' + transaction_hash)
     end
@@ -55,6 +59,11 @@ module BlockCypher
     # Transaction API
     ##################
     
+		def decode_hex(hex)
+			payload = { 'tx' => hex}
+			api_http_post('/txs/decode', json_payload: payload)
+		end
+
     def push_hex(hex)
       payload = { 'tx' => hex }
       api_http_post('/txs/push', json_payload: payload)
@@ -108,6 +117,17 @@ module BlockCypher
 
       res
     end
+
+		def transaction_new_custom(payload)
+			# Build payload yourself, for custom transactions
+			api_http_post('/txs/new', json_payload: payload)
+		end
+
+		def transaction_send_custom(payload)
+			# Send TXSkeleton payload yourself, for custom transactions
+			# You may need to sign your data using another library, like Bitcoin
+			api_http_post('/txs/send', json_payload: payload)
+		end
 
     ##################
     # Address APIs

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -139,6 +139,41 @@ module BlockCypher
       api_http_get("/addrs/#{address}/full")
     end
 
+		##################
+		# Wallet API
+		##################
+		
+		def wallet_create(name, addresses)
+			payload = { 'name' => name, 'addresses' => addresses}
+      api_http_post('/wallets', json_payload: payload)
+		end
+
+		def wallet_get(name)
+			api_http_get('/wallets/' + name)
+		end
+
+		def wallet_add_addr(name, addresses)
+			payload = { 'addresses' => addresses}
+      api_http_post('/wallets/' + name + '/addresses', json_payload: payload)
+		end
+
+		def wallet_get_addr(name)
+			api_http_get('/wallets/' + name + '/addresses')
+		end
+
+		def wallet_delete_addr(name, addresses)
+			addrjoin = addresses.join(";")
+			api_http_delete('/wallets/' + name + '/addresses', query: { address: addrjoin})
+		end
+
+		def wallet_gen_addr(name)
+			api_http_post('/wallets/' + name + '/addresses/generate')
+		end
+
+		def wallet_delete(name)
+			api_http_delete('/wallets/' + name)
+		end
+
     ##################
     # Events API
     ##################
@@ -191,6 +226,8 @@ module BlockCypher
         request = Net::HTTP::Post.new(uri.request_uri)
       elsif http_method == :get
         request = Net::HTTP::Get.new(uri.request_uri)
+			elsif http_method == :delete
+				request = Net::HTTP::Delete.new(uri.request_uri)
       else
         raise 'Invalid HTTP method'
       end
@@ -223,6 +260,10 @@ module BlockCypher
     def api_http_post(api_path, json_payload: nil, query: {})
       api_http_call(:post, api_path, query, json_payload: json_payload)
     end
+
+		def api_http_delete(api_path, query: {})
+			api_http_call(:delete, api_path, query)
+		end
 
     def endpoint_uri(api_path, query)
       uri = URI("https://api.blockcypher.com/#{@version}/#{@currency}/#{@network}#{api_path}")

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -136,6 +136,10 @@ module BlockCypher
 			api_http_post('/txs/send', json_payload: payload)
 		end
 
+		def tx_confidence(tx_hash)
+			api_http_get('/txs/' + tx_hash + '/confidence')
+		end
+
 		##################
 		# Microtx API
 		##################	

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -6,6 +6,8 @@ module BlockCypher
 
   BTC = 'btc'
   LTC = 'ltc'
+	DOGE = 'doge'
+	BCY= 'bcy'
 
   MAIN_NET = 'main'
   TEST_NET = 'test'
@@ -38,6 +40,15 @@ module BlockCypher
 
 		def blockchain()
 			api_http_get('')
+		end
+
+		##################
+		# Faucet API
+		##################
+
+		def faucet(address, amount)
+			payload = { 'address' => address, 'amount' => amount }
+			api_http_post('/faucet', json_payload: payload)
 		end
 
     ##################

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -117,6 +117,11 @@ module BlockCypher
       api_http_post('/addrs')
     end
 
+		def address_generate_multi(pubkeys, script_type)
+			payload = { 'pubkeys' => pubkeys, 'script_type' => script_type}
+      api_http_post('/addrs', json_payload: payload)
+		end
+
     def address_details(address, unspent_only: false)
       api_http_get('/addrs/' + address, query: { unspentOnly: unspent_only } )
     end

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -30,7 +30,7 @@ module BlockCypher
     # Blockchain API
     ##################
 
-		def blockchain_unconfirmed_tx()
+		def blockchain_unconfirmed_tx
 			api_http_get('/txs')
 		end
 
@@ -42,7 +42,7 @@ module BlockCypher
       api_http_get('/blocks/' + block_index, query: params)
     end
 
-		def blockchain()
+		def blockchain
 			api_http_get('')
 		end
 
@@ -254,11 +254,10 @@ module BlockCypher
     # Payments and Forwarding API
     ##################
 
-    def create_forwarding_address(destination, token, callback_url: nil, enable_confirmations: false)
+    def create_forwarding_address(destination, callback_url: nil, enable_confirmations: false)
       payload = {
         destination: destination,
         callback_url: callback_url,
-        token: token,
         enable_confirmations: enable_confirmations
       }
       api_http_post('/payments', json_payload: payload)
@@ -266,9 +265,13 @@ module BlockCypher
 
     alias :create_payments_forwarding :create_forwarding_address
 
-    def list_forwarding_addresses(token)
-      api_http_get("/payments?token=#{token}")
+    def list_forwarding_addresses
+      api_http_get("/payments")
     end
+
+		def delete_forwarding_address(id)
+			api_http_delete("/payments/" + id)
+		end
 
     private
 

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -36,10 +36,13 @@ module BlockCypher
       api_http_get('/blocks/' + block_index)
     end
 
+		def blockchain()
+			api_http_get('')
+		end
+
     ##################
     # Transaction API
     ##################
-    #
     
     def push_hex(hex)
       payload = { 'tx' => hex }
@@ -202,9 +205,6 @@ module BlockCypher
     end
 
     def endpoint_uri(api_path, query)
-      if api_path[0] != '/'
-        api_path = "/#{api_path}"
-      end
       uri = URI("https://api.blockcypher.com/#{@version}/#{@currency}/#{@network}#{api_path}")
       query[:token] = api_token if api_token
       uri.query = URI.encode_www_form(query) unless query.empty?

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -34,8 +34,8 @@ module BlockCypher
       api_http_get('/txs/' + transaction_hash)
     end
 
-    def blockchain_block(block_index)
-      api_http_get('/blocks/' + block_index)
+    def blockchain_block(block_index, params)
+      api_http_get('/blocks/' + block_index, query: params)
     end
 
 		def blockchain()

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -121,8 +121,12 @@ module BlockCypher
       api_http_get('/addrs/' + address, query: { unspentOnly: unspent_only } )
     end
 
+		def address_balance(address)
+			api_http_get('/addrs/' + address + '/balance')
+		end
+
     def address_final_balance(address)
-      details = address_details(address)
+      details = address_balance(address)
       details['final_balance']
     end
 

--- a/spec/blockcypher/api_spec.rb
+++ b/spec/blockcypher/api_spec.rb
@@ -1,5 +1,4 @@
 require 'blockcypher'
-require 'pry'
 
 module BlockCypher
 
@@ -81,7 +80,6 @@ module BlockCypher
 
       it 'lists all forwading addresses created for a given token' do
         forwarding_addresses = api.list_forwarding_addresses("foo")
-        binding.pry
         expect(forwarding_addresses.first["destination"]).to eql(address_1)
       end
 


### PR DESCRIPTION
In doing the ruby samples for the documentation, I came upon the realization that our ruby gem was out of date/missing lots of endpoints, and I wound up adding almost all of them (except for the recently added data endpoint).

I don't think this should break anything for existing customers, though I did wind up refactoring the send-tx code, just to help with microtx usability. Tested it all and it appears to sign/send without a hitch, at least on BCY testnet.

Going forward, I'd probably like to do a bit more refactoring/change the method names around to be more universally consistent, although I know that would probably break customers' current implementations and wanted to discuss more at length with you @matthieu and @hbcheng . I also was unsure about what the right "DELETE" behavior should be, but for now I'm just returning an empty body (which is what's expected with cURL and the 204 status code response).

Feedback most welcome!