### PR TITLE
Raise error for 429 and other 4xx codes

### DIFF
--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -371,11 +371,12 @@ module BlockCypher
       end
 
       response = http.request(request)
+      response_code = response.code.to_i
 
       # Detect errors/return 204 empty body
-      if response.code == '400'
+      if response_code >= 400
         raise Error.new(uri.to_s + ' Response:' + response.body)
-      elsif response.code == '204'
+      elsif response_code == 204
         return nil
       end
 


### PR DESCRIPTION
The API can return a response.body that looks like:

```
"{\"error\": \"Limit of webhooks created exceeded. Please check your account limits and upgrade your plan.\"}"
```

With HTTP code `429`. The current code silently ignores errors like this.