### PR TITLE
Allow any options to pass to event_webhook_subscribe

### DIFF
--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -267,7 +267,7 @@ module BlockCypher
 
       api_http_post('/hooks', json_payload: payload)
     end
-	  
+
     def event_webhook_listall
       api_http_get('/hooks')
     end

--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -259,18 +259,15 @@ module BlockCypher
     # Events API
     ##################
 
-    def event_webhook_subscribe(url, event, confirmations: nil, hash:nil, address:nil, script:nil)
+    def event_webhook_subscribe(url, event, options = {})
       payload = {
         url: url,
         event: event,
-      }
-      payload[:address] = address if address
-      payload[:hash] = hash if hash
-      payload[:script] = script if script
-      payload[:confirmations] = confirmations if confirmations
+      }.merge(options)
+
       api_http_post('/hooks', json_payload: payload)
     end
-
+	  
     def event_webhook_listall
       api_http_get('/hooks')
     end


### PR DESCRIPTION
The previous interface didn't allow passing `confidence` as an option which is supposed to be accepted by the API.