### PR TITLE
Add txlimit param to address_full_txs call

### DIFF
--- a/lib/blockcypher/api.rb
+++ b/lib/blockcypher/api.rb
@@ -203,12 +203,14 @@ module BlockCypher
     end
 
     def address_full_txs(address, limit: 10, before: nil, after: nil,
-                         include_hex: false, omit_wallet_addresses: false, include_confidence: false)
+                         include_hex: false, omit_wallet_addresses: false,
+                         include_confidence: false, txlimit: 20)
       query = {
         limit: limit,
         includeHex: include_hex,
         omitWalletAddresses: omit_wallet_addresses,
-        includeConfidence: include_confidence
+        includeConfidence: include_confidence,
+        txlimit: txlimit
       }
       query[:before] = before if before
       query[:after] = after if after


### PR DESCRIPTION
Adds the optional txlimit parameter to the Blockcypher::Api#address_full_txs
method so that the method can return more than the default 20 inputs and
outputs.